### PR TITLE
Chrome extension popup score and create rating

### DIFF
--- a/backend/adfreereview/url_utils.py
+++ b/backend/adfreereview/url_utils.py
@@ -59,6 +59,12 @@ def check_blog_url(url):
 
 def check_rating_validity(req_data):
     for component, match in rating_infos.items():
+        if req_data[component] == "":
+            continue
         if not match.match(req_data[component]):
             return (False, component)
+    if req_data['adfreescore'] == "":
+        return (False, 'adfreescore')
+    if req_data['contentscore'] == "":
+        return (False, 'contentscore')
     return (True, None)

--- a/backend/adfreereview/views.py
+++ b/backend/adfreereview/views.py
@@ -9,7 +9,7 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
 from urllib.parse import urlparse
-from IPython import embed
+
 
 def myModelList(request):
     if request.method == 'GET':

--- a/backend/adfreereview/views.py
+++ b/backend/adfreereview/views.py
@@ -112,8 +112,8 @@ def get_scores(request, url):
         if len(ratings) == 0:
             return HttpResponse(status=404)
         numrating = len(ratings)
-        adfree_score = sum(rating.adfree_score for rating in ratings) / numrating
-        content_score = sum(rating.content_score for rating in ratings) / numrating
+        adfree_score = round(sum(rating.adfree_score for rating in ratings) / numrating, 2)
+        content_score = round(sum(rating.content_score for rating in ratings) / numrating, 2)
 
         scores = {
             'adfreescore': adfree_score,

--- a/chromeext/send_ratings/popup.js
+++ b/chromeext/send_ratings/popup.js
@@ -1,4 +1,4 @@
-function send_url(e){
+function create_rating(e){
   var url;
   adfreescore = document.getElementById("AdfreeScore").value;
   contentscore = document.getElementById("ContentScore").value;
@@ -8,14 +8,13 @@ function send_url(e){
   xhr.onreadystatechange = function(e) {
     if(xhr.readyState == 4){
       if(xhr.status == 200){
-        window.alert(xhr.responseText);
+        consol.log("Success")
       }else if(xhr.status == 400){
         window.alert("Error: Please return your valid rating");
-      }else{
-        window.alert("Error!");
       }
     }
   };
+
   chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (tabs) {
     url = tabs[0].url;
     xhr.open("POST", base_url, true);  // FIXME localhost
@@ -23,7 +22,7 @@ function send_url(e){
     json_rating = JSON.stringify({adfreescore: adfreescore, contentscore: contentscore, comment:comment, url:url});
     xhr.send(json_rating);
   });
-  window.close();
+  //window.close();
  }
 
 function sign_up(e){
@@ -37,7 +36,7 @@ function duplicate_current_tab(e){
   })
 }
 
-function get_score(){
+function get_post_score(){
   var url;
   chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (tabs) {
     url = tabs[0].url;
@@ -63,9 +62,10 @@ function get_score(){
 
   });
 }
+
 document.addEventListener('DOMContentLoaded', function () {
   document.getElementById("sign_up").addEventListener('click', sign_up);
   document.getElementById("duplicate_current_tab").addEventListener('click', duplicate_current_tab);
-  document.getElementById("SubmitButton").addEventListener('click', send_url);
-  get_score()
+  document.getElementById("SubmitButton").addEventListener('click', create_rating);
+  get_post_score()
 });


### PR DESCRIPTION
See commits in this 2 PR
[chromeext_post](https://github.com/swsnu/swpp17-team12/pull/28)
[chromeext_popupscore](https://github.com/swsnu/swpp17-team12/pull/29)
## POST API
I changed sending ratings from chrome extension process from using GET API to POST API.
Now, comments can include special symbols such as `!@#$%^&*()`.

Please check below screen shots for your understanding.
[django console](https://www.dropbox.com/s/ycvh09pseqq9qqb/Screenshot%202017-11-25%2009.45.42.png)
[django admin page](https://www.dropbox.com/s/dv3ia7pi83telco/Screenshot%202017-11-25%2009.46.00.png)

## Alert when invalid input is received
If input is invalid, alert error message.
adfreescore: 0.0 - 5.0 float
contentscore: 0.0 - 5.0 float
comment: text includint ~`!@#$%^&*()-=_+[]{}:"'><,.?`
url: text starting with `http://`

please check below screen shot for your understanding
[invalid input](https://www.dropbox.com/s/ego5rdl7z8ixw5y/Screenshot%202017-11-25%2010.50.04.png)
[alert message](https://www.dropbox.com/s/lb1sd7viuaxjhpr/Screenshot%202017-11-25%2010.46.23.png)

## Showing Scores [Adfree Score and Content Score]
I implemented some codes for showing `adfreescore` and `contentscore` of post.
When you clicked the chrome extension icon on specific blog post, you can easily see the adfreescore and contentscore of that post. all scores are calculated with mean. 

Please check below screen shots to understand
[showing score](https://www.dropbox.com/s/34jqqw7dtq4bihc/Screenshot%202017-11-25%2011.59.27.png?)

## Alert when the post is not evaluated yet.
When the post is not evaluated yet, chrome extension alert with special text `No one evaluate this post yet. Please be the first one!`

Please check below screen shots to understand
[alert message](https://www.dropbox.com/s/fhskow45nxvw5lq/Screenshot%202017-11-25%2011.59.11.png?)